### PR TITLE
feat: add Language Creation

### DIFF
--- a/frontend/src/modals/CreateContentSourceModal.tsx
+++ b/frontend/src/modals/CreateContentSourceModal.tsx
@@ -11,6 +11,7 @@ import {
   upsertItem,
   upsertSpell,
   upsertTrait,
+  upsertLanguage,
 } from '@content/content-creation';
 import { fetchContentPackage, resetContentStore } from '@content/content-store';
 import { getIconFromContentType, toHTML } from '@content/content-utils';
@@ -64,6 +65,7 @@ import { CreateClassModal } from './CreateClassModal';
 import { CreateItemModal } from './CreateItemModal';
 import { CreateSpellModal } from './CreateSpellModal';
 import { CreateTraitModal } from './CreateTraitModal';
+import { CreateLanguageModal } from './CreateLanguageModal';
 
 export function CreateContentSourceModal(props: {
   opened: boolean;
@@ -965,6 +967,28 @@ function ContentList<
               showNotification({
                 title: `Updated ${result.name}`,
                 message: `Successfully updated trait.`,
+                autoClose: 3000,
+              });
+            }
+
+            handleReset();
+          }}
+          onCancel={() => handleReset()}
+        />
+      )}
+
+      {props.type === 'language' && openedId && (
+        <CreateLanguageModal
+          opened={!!openedId}
+          editId={openedId}
+          onComplete={async (language) => {
+            language.content_source_id = props.sourceId;
+            const result = await upsertLanguage(language);
+
+            if (result) {
+              showNotification({
+                title: `Updated ${result.name}`,
+                message: `Successfully updated language.`,
                 autoClose: 3000,
               });
             }

--- a/frontend/src/modals/CreateLanguageModal.tsx
+++ b/frontend/src/modals/CreateLanguageModal.tsx
@@ -1,0 +1,164 @@
+import RichTextInput from '@common/rich_text_input/RichTextInput';
+import { fetchContentById } from '@content/content-store';
+import { toHTML } from '@content/content-utils';
+import {
+  Button,
+  Group,
+  LoadingOverlay,
+  Modal,
+  ScrollArea,
+  Stack,
+  Select,
+  TextInput,
+  Title,
+  useMantineTheme,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
+import { useQuery } from '@tanstack/react-query';
+import { JSONContent } from '@tiptap/react';
+import { Language, Rarity } from '@typing/content';
+import useRefresh from '@utils/use-refresh';
+import { useState } from 'react';
+
+export function CreateLanguageModal(props: {
+  opened: boolean;
+  editId?: number;
+  editLanguage?: Language;
+  onComplete: (language: Language) => void;
+  onCancel: () => void;
+}) {
+  const [loading, setLoading] = useState(false);
+  const theme = useMantineTheme();
+  const editing =
+    (props.editId !== undefined && props.editId !== -1) || props.editLanguage !== undefined;
+
+  const [displayDescription, refreshDisplayDescription] = useRefresh();
+
+  const { data, isFetching } = useQuery({
+    queryKey: [`get-language-${props.editId}`, { editId: props.editId, editLanguage: props.editLanguage }],
+    queryFn: async ({ queryKey }) => {
+      // @ts-ignore
+      // eslint-disable-next-line
+      const [_key, { editId, editLanguage }] = queryKey as [
+        string,
+        { editId?: number; editLanguage?: Language }
+      ];
+
+      const language = editId ? await fetchContentById<Language>('language', editId) : editLanguage;
+      if (!language) return null;
+
+      form.setInitialValues({
+        ...language,
+      });
+      form.reset();
+      refreshDisplayDescription();
+
+      return language;
+    },
+    enabled: editing,
+    refetchOnWindowFocus: false,
+  });
+
+  const [description, setDescription] = useState<JSONContent>();
+ 
+  const form = useForm<Language>({
+    initialValues: {
+      id: -1,
+      created_at: '',
+      name: '',
+      speakers: '', 
+      script: '', 
+      description: '',
+      rarity: 'COMMON' as Rarity,
+      content_source_id: -1,
+    },
+  });
+
+  const onSubmit = async (values: typeof form.values) => {
+    props.onComplete({
+      ...values,
+    });
+    setTimeout(() => {
+      onReset();
+    }, 1000);
+  };
+
+  const onReset = () => {
+    form.reset();
+    setDescription(undefined);
+  };
+
+  return (
+    <Modal
+      opened={props.opened}
+      onClose={() => {
+        props.onCancel();
+        onReset();
+      }}
+      title={<Title order={3}>{editing ? 'Edit' : 'Create'} Language</Title>}
+      styles={{
+        body: {
+          paddingRight: 2,
+        },
+      }}
+      size={'md'}
+      closeOnClickOutside={false}
+      closeOnEscape={false}
+      keepMounted={false}
+    >
+      <ScrollArea pr={14} scrollbars='y'>
+        <LoadingOverlay visible={loading || isFetching} />
+        <form onSubmit={form.onSubmit(onSubmit)}>
+          <Stack gap={10}>
+            <Group wrap='nowrap' justify='space-between'>
+              <Group wrap='nowrap'>
+                <TextInput label='Name' required {...form.getInputProps('name')} />
+                <TextInput label='Speakers' required {...form.getInputProps('speakers')} />
+                <TextInput label='Script' required {...form.getInputProps('script')} />
+              </Group>
+              <Select
+                label='Rarity'
+                required
+                data={[
+                  { value: 'COMMON', label: 'Common' },
+                  { value: 'UNCOMMON', label: 'Uncommon' },
+                  { value: 'RARE', label: 'Rare' },
+                  { value: 'UNIQUE', label: 'Unique' },
+                ]}
+                w={140}
+                {...form.getInputProps('rarity')}
+              />
+            </Group>
+
+            {displayDescription && (
+              <RichTextInput
+                label='Description'
+                required
+                value={description ?? toHTML(form.values.description)}
+                onChange={(text, json) => {
+                  setDescription(json);
+                  form.setFieldValue('description', text);
+                }}
+              />
+            )}
+
+            <Group justify='flex-end'>
+              <Button
+                variant='default'
+                onClick={() => {
+                  props.onCancel();
+                  onReset();
+                }}
+              >
+                Cancel
+              </Button>
+              <Button type='submit'>{editing ? 'Update' : 'Create'}</Button>
+            </Group>
+          </Stack>
+        </form>
+      </ScrollArea>
+    </Modal>
+  );
+}
+ 

--- a/frontend/src/process/content/content-creation.ts
+++ b/frontend/src/process/content/content-creation.ts
@@ -9,6 +9,7 @@ import {
   Item,
   Spell,
   Trait,
+Language,
 } from "@typing/content";
 import * as _ from "lodash-es";
 import { makeRequest } from "@requests/request-manager";
@@ -88,4 +89,11 @@ export async function upsertTrait(trait: Trait) {
     ...trait,
   });
   return result ? (result === true ? trait : result) : null;
+}
+
+export async function upsertLanguage(language: Language) {
+  const result = await makeRequest<Language | true>("create-language", {
+    ...language,
+  });
+  return result ? (result === true ? language : result) : null;
 }


### PR DESCRIPTION
## Proposed changes

Resolve issue https://github.com/wanderers-guide/wanderers-guide-remaster/issues/15#issue-2002740216. 

Mostly reusing code from other modals and other creation functions to add language creation. 

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

N/A. I tested it out on the backend directly, but I don't want to do that again, because I assume that's bad practice. Related to that, I would appreciate some feedback on how others test out features interacting with the database; do you make a local copy of the database as well? 

## Further comments

I mostly used similar code from other modals to add language creation functionality. A few little things: 
1. The select component for Rarity in the modal has unsightly formatting (uncommon gets split to two lines, etc...)
2. I'm don't know if the modal needs some sort of validate() function like CreateItemModal has, probably for Rarity.  

Working on this issue was mostly a way to start getting a feel for the overall code structure and start to refamiliarize myself with React as a whole and the libraries used. 

Any feedback is greatly appreciated :)